### PR TITLE
refactor: harden supabase client usage

### DIFF
--- a/app/dev/auth-test.tsx
+++ b/app/dev/auth-test.tsx
@@ -1,12 +1,28 @@
 // app/dev/auth-test.tsx (dev-only)
-import React, { useState } from 'react'
-import { View, TextInput, Button, Text } from 'react-native'
-import { supabase } from '@/lib/supabase' // adjust to your client
+import React, { useMemo, useState } from 'react';
+import { View, TextInput, Button, Text } from 'react-native';
+
+import { getSupabaseClient, getSupabaseConfigurationError } from '@/lib/supabase';
 
 export default function AuthTest() {
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [msg, setMsg] = useState('')
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [msg, setMsg] = useState('');
+
+  const supabaseConfigError = getSupabaseConfigurationError();
+  const supabase = useMemo(() => {
+    if (supabaseConfigError) return null;
+    return getSupabaseClient();
+  }, [supabaseConfigError]);
+
+  if (supabaseConfigError) {
+    return (
+      <View style={{ padding: 16, gap: 12 }}>
+        <Text style={{ fontWeight: '600' }}>Supabase configuration missing.</Text>
+        <Text>{supabaseConfigError.message}</Text>
+      </View>
+    );
+  }
 
   return (
     <View style={{ padding: 16, gap: 12 }}>
@@ -14,15 +30,23 @@ export default function AuthTest() {
       <TextInput value={email} onChangeText={setEmail} autoCapitalize="none" style={{ borderWidth: 1, padding: 8 }} />
       <Text>Password</Text>
       <TextInput value={password} onChangeText={setPassword} secureTextEntry style={{ borderWidth: 1, padding: 8 }} />
-      <Button title="Sign in" onPress={async () => {
-        const { error } = await supabase.auth.signInWithPassword({ email, password })
-        setMsg(error ? error.message : 'Signed in')
-      }} />
-      <Button title="Sign out" onPress={async () => {
-        const { error } = await supabase.auth.signOut()
-        setMsg(error ? error.message : 'Signed out')
-      }} />
+      <Button
+        title="Sign in"
+        onPress={async () => {
+          if (!supabase) return;
+          const { error } = await supabase.auth.signInWithPassword({ email, password });
+          setMsg(error ? error.message : 'Signed in');
+        }}
+      />
+      <Button
+        title="Sign out"
+        onPress={async () => {
+          if (!supabase) return;
+          const { error } = await supabase.auth.signOut();
+          setMsg(error ? error.message : 'Signed out');
+        }}
+      />
       <Text>{msg}</Text>
     </View>
-  )
+  );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -3,93 +3,75 @@ import React from 'react';
 import { View, Text, Pressable, ActivityIndicator, Dimensions } from 'react-native';
 import { Link, Stack } from 'expo-router';
 import { useColorScheme } from 'nativewind';
-import { THEME } from '@/lib/theme';
-
 import { Image } from 'expo-image';
 import { FlashList } from '@shopify/flash-list';
 import { useQuery } from '@tanstack/react-query';
-import { fetchApprovedStickers, type Sticker } from '@/features/stickers/api';
 
-// --- header (keeps your theme + toggle) ---
+import { Center } from '@/components/ui/center';
+import { Button } from '@/components/ui/button';
+import { Icon } from '@/components/ui/icon';
+import { THEME } from '@/lib/theme';
+import { fetchApprovedStickers, type Sticker } from '@/features/stickers/api';
+import { getSupabaseConfigurationError } from '@/lib/supabase';
+import { MoonStarIcon, SunIcon } from 'lucide-react-native';
+
+const BASE_HEADER_OPTIONS = {
+  title: 'Stickers',
+  headerTransparent: true,
+  headerShadowVisible: true,
+  headerRight: () => <ThemeToggle />,
+};
+
 const SCREEN_OPTIONS = {
   light: {
-    title: 'Stickers',
-    headerTransparent: true,
-    headerShadowVisible: true,
+    ...BASE_HEADER_OPTIONS,
     headerStyle: { backgroundColor: THEME.light.background },
-    headerRight: () => <ThemeToggle />,
   },
   dark: {
-    title: 'Stickers',
-    headerTransparent: true,
-    headerShadowVisible: true,
+    ...BASE_HEADER_OPTIONS,
     headerStyle: { backgroundColor: THEME.dark.background },
-    headerRight: () => <ThemeToggle />,
   },
 };
 
-// --- layout constants ---
 const GAP = 12;
 const COLS = 2;
-const W = (Dimensions.get('window').width - GAP * (COLS + 1)) / COLS;
+const CARD_WIDTH = (Dimensions.get('window').width - GAP * (COLS + 1)) / COLS;
 
 export default function BrowseScreen() {
   const { colorScheme } = useColorScheme();
-  const isClient = typeof window !== 'undefined';
+  const [isHydrated, setIsHydrated] = React.useState(false);
 
-  // Trim env (avoids hidden whitespace issues)
-  const SB_URL = (process.env.EXPO_PUBLIC_SUPABASE_URL ?? '').trim();
-  const SB_KEY = (process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? '').trim();
-
-  // Log once so you can eyeball them in the console
   React.useEffect(() => {
-    if (!isClient) return;
-    console.log('[env] URL =', SB_URL);
-    console.log('[env] KEY prefix =', SB_KEY.slice(0, 8));
-    if (!SB_URL.startsWith('https://')) {
-      console.warn('[env] URL is missing https:// or malformed');
-    }
-    if (!SB_KEY) {
-      console.warn('[env] anon key missing');
-    }
-  }, [isClient, SB_URL, SB_KEY]);
+    setIsHydrated(true);
+  }, []);
 
-  const { data, isLoading, isError, refetch, error, isFetching } = useQuery({
+  const supabaseConfigError = getSupabaseConfigurationError();
+
+  React.useEffect(() => {
+    if (supabaseConfigError) {
+      console.warn(supabaseConfigError.message);
+    }
+  }, [supabaseConfigError]);
+
+  const {
+    data: stickers = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+    isFetching,
+  } = useQuery<Sticker[]>({
     queryKey: ['stickers'],
     queryFn: fetchApprovedStickers,
-    enabled: isClient, // don't run during SSR
+    enabled: isHydrated,
     retry: 0,
   });
 
-  const stickers = (data ?? []) as Sticker[];
-
   React.useEffect(() => {
-    if (isError) console.error('[stickers] query error:', error);
+    if (isError && error) {
+      console.error('[stickers] query error:', error);
+    }
   }, [isError, error]);
-
-  // --- PROBE: hit REST directly and print the raw response ---
-  React.useEffect(() => {
-    if (!isClient || !SB_URL || !SB_KEY) return;
-
-    (async () => {
-      const apiUrl = `${SB_URL}/rest/v1/stickers?select=id&limit=1`;
-      try {
-        console.log('[probe] GET', apiUrl);
-        const res = await fetch(apiUrl, {
-          method: 'GET',
-          headers: {
-            apikey: SB_KEY,
-            Authorization: `Bearer ${SB_KEY}`,
-          },
-        });
-        const text = await res.text();
-        console.log('[probe] status', res.status);
-        console.log('[probe] body', text);
-      } catch (e: any) {
-        console.error('[probe] failed', e?.name, e?.message || e);
-      }
-    })();
-  }, [isClient, SB_URL, SB_KEY]);
 
   return (
     <>
@@ -104,11 +86,12 @@ export default function BrowseScreen() {
         <Center>
           <Text>Couldn’t load stickers.</Text>
           <Text style={{ color: '#666', marginTop: 6, textAlign: 'center' }}>
-            {(error as any)?.message ?? 'Open the browser console for details.'}
+            {(error as Error)?.message ?? 'Open the browser console for details.'}
           </Text>
           <Pressable
             onPress={() => refetch()}
-            style={{ marginTop: 12, padding: 10, backgroundColor: '#eee', borderRadius: 8 }}>
+            style={{ marginTop: 12, padding: 10, backgroundColor: '#eee', borderRadius: 8 }}
+          >
             <Text>Retry</Text>
           </Pressable>
         </Center>
@@ -122,7 +105,7 @@ export default function BrowseScreen() {
       ) : (
         <FlashList<Sticker>
           data={stickers}
-          estimatedItemSize={W + 40}
+          estimatedItemSize={CARD_WIDTH + 40}
           numColumns={COLS}
           keyExtractor={(item) => item.id}
           ItemSeparatorComponent={() => <View style={{ height: GAP }} />}
@@ -130,15 +113,10 @@ export default function BrowseScreen() {
           refreshing={isFetching}
           onRefresh={() => refetch()}
           renderItem={({ item }) => (
-            <View style={{ width: W, marginHorizontal: GAP / 2 }}>
+            <View style={{ width: CARD_WIDTH, marginHorizontal: GAP / 2 }}>
               <Link href={`/sticker/${item.id}`} asChild>
                 <Pressable style={{ borderRadius: 12, overflow: 'hidden', backgroundColor: '#f4f4f4' }}>
-                  <Image
-                    source={{ uri: item.image_url }}
-                    style={{ width: '100%', height: W }}
-                    contentFit="cover"
-                    transition={100}
-                  />
+                  <StickerArtwork uri={item.image_url} size={CARD_WIDTH} />
                   <View style={{ padding: 8 }}>
                     <Text numberOfLines={1} style={{ fontWeight: '600' }}>
                       {item.title ?? 'Untitled'}
@@ -159,24 +137,47 @@ export default function BrowseScreen() {
   );
 }
 
-function Center({ children }: { children: React.ReactNode }) {
-  return <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 }}>{children}</View>;
-}
-
-// --- your existing ThemeToggle, unchanged ---
-import { Button } from '@/components/ui/button';
-import { Icon } from '@/components/ui/icon';
-import { MoonStarIcon, SunIcon } from 'lucide-react-native';
-
 const THEME_ICONS = {
   light: SunIcon,
   dark: MoonStarIcon,
 };
+
 function ThemeToggle() {
   const { colorScheme, toggleColorScheme } = useColorScheme();
   return (
     <Button onPressIn={toggleColorScheme} size="icon" variant="ghost" className="rounded-full web:mx-4">
       <Icon as={THEME_ICONS[colorScheme ?? 'light']} className="size-5" />
     </Button>
+  );
+}
+
+function StickerArtwork({ uri, size }: { uri: string | null; size: number }) {
+  const [failed, setFailed] = React.useState(false);
+  const cleanedUri = uri?.trim();
+
+  if (!cleanedUri || failed) {
+    return (
+      <View
+        style={{
+          width: '100%',
+          height: size,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#e7e7e7',
+        }}
+      >
+        <Text style={{ color: '#666', fontSize: 12 }}>Image unavailable</Text>
+      </View>
+    );
+  }
+
+  return (
+    <Image
+      source={{ uri: cleanedUri }}
+      style={{ width: '100%', height: size }}
+      contentFit="cover"
+      transition={100}
+      onError={() => setFailed(true)}
+    />
   );
 }

--- a/app/sticker/[id].tsx
+++ b/app/sticker/[id].tsx
@@ -1,60 +1,99 @@
 // app/sticker/[id].tsx
-import React from 'react'
-import { View, Text, ActivityIndicator, ScrollView, Pressable, RefreshControl, Alert, Platform } from 'react-native'
-import { Stack, useLocalSearchParams, useRouter } from 'expo-router'
-import { Image } from 'expo-image'
-import { useQuery } from '@tanstack/react-query'
-import { fetchStickerById, fetchExperiences, type Experience } from '@/features/stickers/api'
-import { openExperience } from '@/lib/experience'
+import React from 'react';
+import { View, Text, ActivityIndicator, ScrollView, Pressable, RefreshControl, Alert } from 'react-native';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { Image } from 'expo-image';
+import { useQuery } from '@tanstack/react-query';
+
+import { Center } from '@/components/ui/center';
+import { GhostButton } from '@/components/ui/ghost-button';
+import { ErrorView } from '@/components/ui/error-view';
+import { fetchStickerById, fetchExperiences, type Experience, type Sticker } from '@/features/stickers/api';
+import { openExperience } from '@/lib/experience';
 
 export default function StickerDetails() {
-  const router = useRouter()
-  const { id } = useLocalSearchParams<{ id?: string | string[] }>()
-  const sid = Array.isArray(id) ? id[0] : id
-  const isClient = typeof window !== 'undefined' || Platform.OS !== 'web'
-
-  // Sticker query (client-only; no SSR)
-  const stickerQ = useQuery({
-    queryKey: ['sticker', sid],
-    queryFn: () => fetchStickerById(sid!),
-    enabled: isClient && !!sid,
-    retry: 1,
-  })
-
-  // Experiences (optional; non-blocking)
-  const expQ = useQuery({
-    queryKey: ['experiences', sid],
-    queryFn: () => fetchExperiences(sid!),
-    enabled: isClient && !!sid,
-    retry: 1,
-  })
+  const router = useRouter();
+  const { id } = useLocalSearchParams<{ id?: string | string[] }>();
+  const sid = Array.isArray(id) ? id[0] : id;
+  const [isHydrated, setIsHydrated] = React.useState(false);
 
   React.useEffect(() => {
-    if (stickerQ.isError) console.error('[sticker] error', stickerQ.error)
-    if (expQ.isError) console.warn('[experiences] error (non-blocking)', expQ.error)
-  }, [stickerQ.isError, expQ.isError])
+    setIsHydrated(true);
+  }, []);
+
+  const canQuery = isHydrated && !!sid;
+
+  const {
+    data: sticker,
+    isLoading: isStickerLoading,
+    isFetching: isStickerFetching,
+    isError: isStickerError,
+    error: stickerError,
+    refetch: refetchSticker,
+  } = useQuery<Sticker | null>({
+    queryKey: ['sticker', sid],
+    queryFn: () => {
+      if (!sid) {
+        throw new Error('Missing sticker id');
+      }
+      return fetchStickerById(sid);
+    },
+    enabled: canQuery,
+    retry: 1,
+  });
+
+  const {
+    data: experiences = [],
+    isLoading: isExperiencesLoading,
+    isFetching: isExperiencesFetching,
+    isError: isExperiencesError,
+    error: experiencesError,
+    refetch: refetchExperiences,
+  } = useQuery<Experience[]>({
+    queryKey: ['experiences', sid],
+    queryFn: () => {
+      if (!sid) {
+        throw new Error('Missing sticker id');
+      }
+      return fetchExperiences(sid);
+    },
+    enabled: canQuery,
+    retry: 1,
+  });
+
+  React.useEffect(() => {
+    if (isStickerError && stickerError) {
+      console.error('[sticker] error', stickerError);
+    }
+    if (isExperiencesError && experiencesError) {
+      console.warn('[experiences] error (non-blocking)', experiencesError);
+    }
+  }, [isStickerError, stickerError, isExperiencesError, experiencesError]);
 
   const onRefresh = React.useCallback(() => {
-    if (!sid) return
-    stickerQ.refetch()
-    expQ.refetch()
-  }, [sid])
+    if (!sid) return;
+    void refetchSticker();
+    void refetchExperiences();
+  }, [sid, refetchSticker, refetchExperiences]);
 
   const onOpen = React.useCallback(async (exp: Experience) => {
     try {
-      await openExperience(exp)
+      await openExperience(exp);
     } catch (e: any) {
-      Alert.alert('Could not open', e?.message ?? 'Unknown error')
+      Alert.alert('Could not open', e?.message ?? 'Unknown error');
     }
-  }, [])
+  }, []);
 
-  const getCtaText = (exp: Experience) => {
+  const getCtaText = React.useCallback((exp: Experience) => {
     switch (exp.type) {
-      case 'ar': return 'Open AR'
-      case 'url': return 'Open Link'
-      default: return `Open ${String(exp.type).replace('_', ' ')}`
+      case 'ar':
+        return 'Open AR';
+      case 'url':
+        return 'Open Link';
+      default:
+        return `Open ${String(exp.type).replace(/_/g, ' ')}`;
     }
-  }
+  }, []);
 
   if (!sid) {
     return (
@@ -62,64 +101,59 @@ export default function StickerDetails() {
         <Text>Missing sticker id.</Text>
         <GhostButton onPress={() => router.back()}>Go back</GhostButton>
       </Center>
-    )
+    );
   }
 
-  if (stickerQ.isLoading) {
+  if (isStickerLoading) {
     return (
       <Center>
         <ActivityIndicator />
         <Text style={{ marginTop: 8 }}>Loading…</Text>
       </Center>
-    )
+    );
   }
-
-  const s = stickerQ.data // may be null if not found or not allowed by RLS
 
   return (
     <>
-      <Stack.Screen options={{ title: s?.title ?? 'Sticker' }} />
-      {!s ? (
+      <Stack.Screen options={{ title: sticker?.title ?? 'Sticker' }} />
+      {!sticker ? (
         <Center>
           <Text style={{ fontSize: 16, fontWeight: '600' }}>Sticker not found.</Text>
           <Text style={{ color: '#666', marginTop: 6, textAlign: 'center' }}>
             id: <Text style={{ fontWeight: '600' }}>{sid}</Text>
           </Text>
-          <GhostButton style={{ marginTop: 12 }} onPress={() => router.back()}>Go back</GhostButton>
+          <GhostButton style={{ marginTop: 12 }} onPress={() => router.back()}>
+            Go back
+          </GhostButton>
         </Center>
       ) : (
         <ScrollView
           contentContainerStyle={{ padding: 16 }}
           refreshControl={
-            <RefreshControl refreshing={stickerQ.isFetching || expQ.isFetching} onRefresh={onRefresh} />
+            <RefreshControl refreshing={isStickerFetching || isExperiencesFetching} onRefresh={onRefresh} />
           }
         >
-          <Image
-            source={{ uri: s.image_url }}
-            style={{ width: '100%', aspectRatio: 1, borderRadius: 12, backgroundColor: '#f2f2f2' }}
-            contentFit="cover"
-            transition={150}
-          />
+          <Artwork uri={sticker.image_url} />
 
           <View style={{ marginTop: 12 }}>
-            <Text style={{ fontSize: 20, fontWeight: '700' }}>{s.title ?? 'Untitled'}</Text>
-            {!!s.artist_name && <Text style={{ color: '#666', marginTop: 4 }}>{s.artist_name}</Text>}
+            <Text style={{ fontSize: 20, fontWeight: '700' }}>{sticker.title ?? 'Untitled'}</Text>
+            {!!sticker.artist_name && <Text style={{ color: '#666', marginTop: 4 }}>{sticker.artist_name}</Text>}
           </View>
 
           <View style={{ marginTop: 16 }}>
             <Text style={{ fontSize: 16, fontWeight: '600', marginBottom: 8 }}>Experience</Text>
 
-            {expQ.isLoading ? (
+            {isExperiencesLoading ? (
               <ActivityIndicator />
-            ) : expQ.isError ? (
+            ) : isExperiencesError ? (
               <ErrorView
-                message="Couldn’t load experience."
-                onRetry={() => expQ.refetch()}
+                message={(experiencesError as Error)?.message ?? 'Couldn’t load experience.'}
+                onRetry={() => void refetchExperiences()}
               />
-            ) : (expQ.data ?? []).length === 0 ? (
+            ) : experiences.length === 0 ? (
               <Text style={{ color: '#666' }}>No attached experience.</Text>
             ) : (
-              (expQ.data as Experience[]).map((exp) => (
+              experiences.map((exp) => (
                 <Pressable
                   key={exp.id}
                   onPress={() => onOpen(exp)}
@@ -132,9 +166,7 @@ export default function StickerDetails() {
                     alignItems: 'center',
                   }}
                 >
-                  <Text style={{ color: 'white', fontWeight: '600' }}>
-                    {getCtaText(exp)}
-                  </Text>
+                  <Text style={{ color: 'white', fontWeight: '600' }}>{getCtaText(exp)}</Text>
                 </Pressable>
               ))
             )}
@@ -142,48 +174,37 @@ export default function StickerDetails() {
         </ScrollView>
       )}
     </>
-  )
+  );
 }
 
-function Center({ children }: { children: React.ReactNode }) {
-  return <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 }}>{children}</View>
-}
+function Artwork({ uri }: { uri: string | null }) {
+  const [failed, setFailed] = React.useState(false);
+  const cleanedUri = uri?.trim();
 
-function GhostButton({
-  children,
-  onPress,
-  style,
-}: {
-  children: React.ReactNode
-  onPress?: () => void
-  style?: any
-}) {
+  if (!cleanedUri || failed) {
+    return (
+      <View
+        style={{
+          width: '100%',
+          aspectRatio: 1,
+          borderRadius: 12,
+          backgroundColor: '#f2f2f2',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Text style={{ color: '#666' }}>Image unavailable</Text>
+      </View>
+    );
+  }
+
   return (
-    <Pressable
-      onPress={onPress}
-      style={[
-        {
-          paddingVertical: 10,
-          paddingHorizontal: 14,
-          borderRadius: 10,
-          borderWidth: 1,
-          borderColor: '#cfd8d3',
-          backgroundColor: 'white',
-          marginTop: 8,
-        },
-        style,
-      ]}
-    >
-      <Text style={{ color: '#004226', fontWeight: '600' }}>{children}</Text>
-    </Pressable>
-  )
-}
-
-function ErrorView({ message, onRetry }: { message: string; onRetry?: () => void }) {
-  return (
-    <View style={{ padding: 12, borderWidth: 1, borderColor: '#ffd6d6', backgroundColor: '#fff5f5', borderRadius: 10 }}>
-      <Text style={{ color: '#b00020', marginBottom: 8 }}>{message}</Text>
-      {onRetry && <GhostButton onPress={onRetry}>Try again</GhostButton>}
-    </View>
-  )
+    <Image
+      source={{ uri: cleanedUri }}
+      style={{ width: '100%', aspectRatio: 1, borderRadius: 12, backgroundColor: '#f2f2f2' }}
+      contentFit="cover"
+      transition={150}
+      onError={() => setFailed(true)}
+    />
+  );
 }

--- a/components/ui/center.tsx
+++ b/components/ui/center.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { View, type ViewProps } from 'react-native';
+
+type CenterProps = ViewProps & {
+  children: React.ReactNode;
+};
+
+export function Center({ children, style, ...props }: CenterProps) {
+  return (
+    <View
+      style={[{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 }, style]}
+      {...props}
+    >
+      {children}
+    </View>
+  );
+}

--- a/components/ui/error-view.tsx
+++ b/components/ui/error-view.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { View, Text, type ViewProps } from 'react-native';
+
+import { GhostButton } from '@/components/ui/ghost-button';
+
+type ErrorViewProps = ViewProps & {
+  message: string;
+  onRetry?: () => void;
+  retryLabel?: string;
+};
+
+export function ErrorView({ message, onRetry, retryLabel = 'Try again', style, ...props }: ErrorViewProps) {
+  return (
+    <View
+      style={[{ padding: 12, borderWidth: 1, borderColor: '#ffd6d6', backgroundColor: '#fff5f5', borderRadius: 10 }, style]}
+      {...props}
+    >
+      <Text style={{ color: '#b00020', marginBottom: onRetry ? 8 : 0 }}>{message}</Text>
+      {onRetry ? <GhostButton onPress={onRetry}>{retryLabel}</GhostButton> : null}
+    </View>
+  );
+}

--- a/components/ui/ghost-button.tsx
+++ b/components/ui/ghost-button.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Pressable, Text, type PressableProps } from 'react-native';
+
+type GhostButtonProps = PressableProps & {
+  children: React.ReactNode;
+};
+
+export function GhostButton({ children, style, ...props }: GhostButtonProps) {
+  return (
+    <Pressable
+      style={(state) => [
+        {
+          paddingVertical: 10,
+          paddingHorizontal: 14,
+          borderRadius: 10,
+          borderWidth: 1,
+          borderColor: '#cfd8d3',
+          backgroundColor: 'white',
+          marginTop: 8,
+          opacity: state.pressed ? 0.85 : 1,
+        },
+        typeof style === 'function' ? style(state) : style,
+      ]}
+      {...props}
+    >
+      <Text style={{ color: '#004226', fontWeight: '600', textAlign: 'center' }}>{children}</Text>
+    </Pressable>
+  );
+}

--- a/docs/improvement-suggestions.md
+++ b/docs/improvement-suggestions.md
@@ -1,0 +1,32 @@
+# Codebase Improvement Suggestions
+
+This document captures potential enhancements identified while reviewing the current codebase. The items are grouped by file to make the follow-up work easier to triage.
+
+## `app/index.tsx`
+
+- **Run data queries reliably on native** – `isClient` is computed only from `typeof window !== 'undefined'`, which is `false` on iOS and Android even though the component is client-side. Because the queries are gated by this flag, native builds will never fetch stickers. Consider deriving the flag from `Platform.OS !== 'web'` or directly using Expo Router's `useFocusEffect`/`useAppState` guards to avoid SSR while still enabling native execution.
+- **Avoid logging sensitive environment info** – The effect that logs `EXPO_PUBLIC_SUPABASE_URL` and the first characters of the anon key is useful during debugging but risks exposing credentials in production builds and in Expo Go logs. Replacing it with explicit validation (e.g., using `console.warn` only when the values are missing) or stripping it entirely before release would be safer.
+- **Deduplicate header configuration** – `SCREEN_OPTIONS` duplicates the `title`, `headerTransparent`, `headerShadowVisible`, and `headerRight` definitions. Extract the shared settings into a base object and only override the pieces that depend on the scheme (the background color), which will simplify future tweaks.
+- **Handle empty or broken image URLs gracefully** – Rendering assumes `item.image_url` is defined. Providing a fallback URI or placeholder component when the URL is empty (or when the image fails to load) would harden the list against inconsistent data.
+- **Broaden Supabase response typing** – Casting `data` to `Sticker[]` bypasses type safety. Returning `data ?? []` directly and adjusting the calling code to narrow the type (or defining `fetchApprovedStickers` to resolve with `Sticker[]`) would avoid unnecessary casting and surface schema drift sooner.
+- **Probe effect cleanup** – The REST "probe" `useEffect` performs a background fetch solely for logging. Once connectivity is confirmed this should either be behind a development flag or removed, because it duplicates work, adds noise, and forces a second request for each load.
+
+## `app/sticker/[id].tsx`
+
+- **Normalize parameter handling** – The component dereferences `sid!` in the query functions. Guarding before invoking the queries (or using the `enabled` flag plus a type-safe helper that narrows `sid`) would remove the non-null assertions and help TypeScript enforce the invariant.
+- **Stabilize effect dependencies** – The error logging effect depends on `stickerQ.error` and `expQ.error`, but the dependency array only lists the boolean flags. Include the error objects (or, alternatively, convert to `useEffect(() => { ... }, [stickerQ.status, expQ.status])`) to avoid stale closures.
+- **Extract shared UI primitives** – `Center`, `GhostButton`, and `ErrorView` are implemented inline. Moving them into `components/ui` would promote reuse, keep styling consistent across screens, and make it easier to unit test them.
+- **Improve experience CTA labels** – `getCtaText` falls back to `String(exp.type).replace('_', ' ')`, which only replaces the first underscore. Using a more robust formatter (e.g., `exp.type.replace(/_/g, ' ')`) or a mapping constant would prevent awkward copy for new types.
+- **Protect against empty image URLs** – As in the browse screen, render a placeholder when `s.image_url` is missing or fails to load to avoid blank sections and runtime warnings.
+
+## `lib/supabase.ts`
+
+- **Fail fast without crashing the bundle** – Throwing an error at module initialization prevents the entire app from loading when environment variables are missing (including in Expo's preview environments). Instead, consider logging a descriptive warning and returning a no-op client in development, or defer the validation until the client is first used so the rest of the UI can still render with a friendly error state.
+- **Unify storage adapters** – The current code duplicates storage adapter wiring for web and native. Extracting a helper that returns the correct adapter would reduce branching and make it easier to add support for SecureStore if persistent sessions are ever needed on native.
+
+## Data-layer follow-ups
+
+- **Limit Supabase selections** – Each query uses `.select('*')`. Fetching only the fields actually required by the UI (e.g., `id`, `title`, `artist_name`, `image_url`, `status`) will reduce payload size and future-proof the app if sensitive columns are added.
+- **Add query error boundaries** – The UI currently logs errors but keeps the last loaded data around. Leveraging React Query's `useErrorBoundary` or displaying a dedicated error view on the list screen would give users clearer feedback when Supabase is misconfigured.
+
+These improvements should help harden the app for real-world use while keeping the developer experience smooth.

--- a/features/stickers/api.ts
+++ b/features/stickers/api.ts
@@ -1,11 +1,11 @@
 // features/stickers/api.ts
-import { supabase } from '@/lib/supabase';
+import { getSupabaseClient } from '@/lib/supabase';
 
 export type Sticker = {
   id: string;
   title: string | null;
   artist_name: string | null;
-  image_url: string;
+  image_url: string | null;
   status: 'pending' | 'approved' | 'flagged';
   created_at?: string;
 };
@@ -17,41 +17,47 @@ export type Experience = {
   payload: Record<string, any> | null;
 };
 
+const STICKER_FIELDS = 'id,title,artist_name,image_url,status,created_at';
+const EXPERIENCE_FIELDS = 'id,sticker_id,type,payload';
+
 /** Grid list */
 export async function fetchApprovedStickers(): Promise<Sticker[]> {
+  const supabase = getSupabaseClient();
   const { data, error } = await supabase
     .from('stickers')
-    .select('*')
+    .select(STICKER_FIELDS)
     .eq('status', 'approved')
     .order('created_at', { ascending: false });
 
   if (error) throw error;
-  return data ?? [];
+  return (data as Sticker[] | null) ?? [];
 }
 
 /** Details page */
 export async function fetchStickerById(id: string) {
+  const supabase = getSupabaseClient();
   const { data, error } = await supabase
     .from('stickers')
-    .select('*')
+    .select(STICKER_FIELDS)
     .eq('id', id)
     .eq('status', 'approved')
     .maybeSingle(); // null if not found instead of throwing
 
   if (error) throw error;
-  return data; // Sticker | null
+  return (data as Sticker | null) ?? null; // Sticker | null
 }
 
 /** Optional attached experiences */
 export async function fetchExperiences(stickerId: string): Promise<Experience[]> {
+  const supabase = getSupabaseClient();
   const { data, error } = await supabase
     .from('experiences')
-    .select('*')
+    .select(EXPERIENCE_FIELDS)
     .eq('sticker_id', stickerId);
 
   if (error) {
     console.warn('[supabase] experiences error', error);
     return [];
   }
-  return data ?? [];
+  return (data as Experience[] | null) ?? [];
 }

--- a/lib/logAuthEvent.ts
+++ b/lib/logAuthEvent.ts
@@ -1,19 +1,26 @@
 // src/lib/logAuthEvent.ts
-import { supabase } from './supabase'  // your existing client
+import { getSupabaseClient, getSupabaseConfigurationError } from './supabase';
 
 export async function logAuthEvent(input: {
-  type: 'user.signed_in' | 'user.signed_out'
-  session_id: string
-  platform?: 'web' | 'ios' | 'android'
-  app_version?: string
-  context?: Record<string, any>
-  auth_method?: string
-  is_new_user?: boolean
-  is_fresh_session?: boolean
-  reason?: 'user_action' | 'token_expired' | 'admin_revoke' | 'app_quit' | 'unknown'
-  duration_ms?: number
-  project_env?: 'dev' | 'staging' | 'prod'
+  type: 'user.signed_in' | 'user.signed_out';
+  session_id: string;
+  platform?: 'web' | 'ios' | 'android';
+  app_version?: string;
+  context?: Record<string, any>;
+  auth_method?: string;
+  is_new_user?: boolean;
+  is_fresh_session?: boolean;
+  reason?: 'user_action' | 'token_expired' | 'admin_revoke' | 'app_quit' | 'unknown';
+  duration_ms?: number;
+  project_env?: 'dev' | 'staging' | 'prod';
 }) {
-  const { error } = await supabase.functions.invoke('log-event', { body: input })
-  if (error) console.warn('logAuthEvent failed:', error)
+  const configError = getSupabaseConfigurationError();
+  if (configError) {
+    console.warn('logAuthEvent skipped:', configError.message);
+    return;
+  }
+
+  const supabase = getSupabaseClient();
+  const { error } = await supabase.functions.invoke('log-event', { body: input });
+  if (error) console.warn('logAuthEvent failed:', error);
 }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,49 +1,99 @@
 // lib/supabase.ts
 import 'react-native-url-polyfill/auto';
 import { Platform } from 'react-native';
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 const rawUrl = (process.env.EXPO_PUBLIC_SUPABASE_URL || '').trim();
 const rawKey = (process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY || '').trim();
 
-if (!rawUrl || !/^https:\/\/.+\.supabase\.co/.test(rawUrl)) {
-  throw new Error(
-    `[Supabase] EXPO_PUBLIC_SUPABASE_URL is missing/invalid. Got: "${rawUrl || 'undefined'}".
-     Copy "Project URL" from Supabase → Settings → API (it looks like https://xxxxx.supabase.co).`
+const configIssues: string[] = [];
+
+if (!rawUrl) {
+  configIssues.push(
+    'EXPO_PUBLIC_SUPABASE_URL is missing. Copy the "Project URL" from Supabase → Settings → API.'
+  );
+} else if (!/^https:\/\/.+\.supabase\.co/.test(rawUrl)) {
+  configIssues.push(
+    `EXPO_PUBLIC_SUPABASE_URL looks malformed (received "${rawUrl}"). It should match https://xxxx.supabase.co.`
   );
 }
-if (!rawKey || !rawKey.startsWith('eyJ')) {
-  throw new Error(
-    `[Supabase] EXPO_PUBLIC_SUPABASE_ANON_KEY is missing/invalid. Got prefix: "${rawKey.slice(0,8)}".
-     Copy the "anon public" key from Supabase → Settings → API.`
+
+if (!rawKey) {
+  configIssues.push(
+    'EXPO_PUBLIC_SUPABASE_ANON_KEY is missing. Copy the "anon public" key from Supabase → Settings → API.'
   );
+} else if (!rawKey.startsWith('eyJ')) {
+  configIssues.push(
+    `EXPO_PUBLIC_SUPABASE_ANON_KEY looks malformed (prefix "${rawKey.slice(0, 8)}").`
+  );
+}
+
+const configurationError =
+  configIssues.length > 0 ? new Error(`[Supabase] ${configIssues.join(' ')}`) : null;
+
+if (configurationError && process.env.NODE_ENV !== 'production') {
+  console.warn(configurationError.message);
 }
 
 const isServer = typeof window === 'undefined';
 
-let storage: any = undefined;
-if (!isServer && Platform.OS === 'web') {
-  storage = {
-    getItem: (k: string) => Promise.resolve(window.localStorage.getItem(k)),
-    setItem: (k: string, v: string) => Promise.resolve(window.localStorage.setItem(k, v)),
-    removeItem: (k: string) => Promise.resolve(window.localStorage.removeItem(k)),
-  };
-}
-if (!isServer && Platform.OS !== 'web') {
+type StorageAdapter = {
+  getItem: (key: string) => Promise<string | null>;
+  setItem: (key: string, value: string) => Promise<void>;
+  removeItem: (key: string) => Promise<void>;
+} | null;
+
+function createStorageAdapter(): StorageAdapter {
+  if (isServer) return null;
+
+  if (Platform.OS === 'web') {
+    const storage = window.localStorage;
+    return {
+      getItem: (key: string) => Promise.resolve(storage.getItem(key)),
+      setItem: (key: string, value: string) => {
+        storage.setItem(key, value);
+        return Promise.resolve();
+      },
+      removeItem: (key: string) => {
+        storage.removeItem(key);
+        return Promise.resolve();
+      },
+    };
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const AsyncStorage = require('@react-native-async-storage/async-storage').default;
-  storage = {
-    getItem: (k: string) => AsyncStorage.getItem(k),
-    setItem: (k: string, v: string) => AsyncStorage.setItem(k, v),
-    removeItem: (k: string) => AsyncStorage.removeItem(k),
+  return {
+    getItem: (key: string) => AsyncStorage.getItem(key),
+    setItem: (key: string, value: string) => AsyncStorage.setItem(key, value),
+    removeItem: (key: string) => AsyncStorage.removeItem(key),
   };
 }
 
-export const supabase = createClient(rawUrl, rawKey, {
-  auth: {
-    persistSession: !isServer,
-    autoRefreshToken: !isServer,
-    detectSessionInUrl: !isServer && Platform.OS === 'web',
-    storage,
-  },
-});
+const storage = createStorageAdapter() ?? undefined;
+let cachedClient: SupabaseClient | null = null;
+
+export const isSupabaseConfigured = configurationError == null;
+
+export function getSupabaseConfigurationError() {
+  return configurationError;
+}
+
+export function getSupabaseClient(): SupabaseClient {
+  if (configurationError) {
+    throw configurationError;
+  }
+
+  if (!cachedClient) {
+    cachedClient = createClient(rawUrl, rawKey, {
+      auth: {
+        persistSession: !isServer,
+        autoRefreshToken: !isServer,
+        detectSessionInUrl: !isServer && Platform.OS === 'web',
+        storage,
+      },
+    });
+  }
+
+  return cachedClient;
+}


### PR DESCRIPTION
## Summary
- defer Supabase client creation until runtime and surface readable configuration errors
- tighten sticker data fetching and UI by adding loading guards, fallback imagery, and shared primitives
- update downstream callers to handle missing Supabase configuration gracefully

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e660307af883329a19c79b916ba21e