### PR TITLE
fix: add missing header action imports

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -8,6 +8,8 @@ import { FlashList } from '@shopify/flash-list';
 import { useQuery } from '@tanstack/react-query';
 
 import { Center } from '@/components/ui/center';
+import { Button } from '@/components/ui/button';
+import { Icon } from '@/components/ui/icon';
 import { THEME } from '@/lib/theme';
 import { fetchApprovedStickers, type Sticker } from '@/features/stickers/api';
 import { getSupabaseConfigurationError } from '@/lib/supabase';


### PR DESCRIPTION
## Summary
- import the shared Button and Icon components in the main browse screen so header actions compile

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e6745506f4833291a0b99188172b42