### PR TITLE
Handle sticker location schema drift

### DIFF
--- a/features/stickers/api.ts
+++ b/features/stickers/api.ts
@@ -1,6 +1,8 @@
 // features/stickers/api.ts
 import { getSupabaseClient } from '@/lib/supabase';
 
+type UnknownRecord = Record<string, unknown>;
+
 export type Sticker = {
   id: string;
   title: string | null;
@@ -19,34 +21,43 @@ export type Experience = {
   payload: Record<string, any> | null;
 };
 
-const STICKER_FIELDS = 'id,title,artist_name,image_url,latitude,longitude,status,created_at';
+const STICKER_FIELD_VARIANTS = [
+  'id,title,artist_name,image_url,latitude,longitude,status,created_at',
+  '*',
+] as const;
 const EXPERIENCE_FIELDS = 'id,sticker_id,type,payload';
 
 /** Grid list */
 export async function fetchApprovedStickers(): Promise<Sticker[]> {
   const supabase = getSupabaseClient();
-  const { data, error } = await supabase
-    .from('stickers')
-    .select(STICKER_FIELDS)
-    .eq('status', 'approved')
-    .order('created_at', { ascending: false });
+  const rows = await withFieldFallback<StickerRow[]>(
+    (fields) =>
+      supabase
+        .from('stickers')
+        .select(fields)
+        .eq('status', 'approved')
+        .order('created_at', { ascending: false }),
+    [],
+  );
 
-  if (error) throw error;
-  return (data as Sticker[] | null) ?? [];
+  return rows.map(normalizeStickerRow);
 }
 
 /** Details page */
 export async function fetchStickerById(id: string) {
   const supabase = getSupabaseClient();
-  const { data, error } = await supabase
-    .from('stickers')
-    .select(STICKER_FIELDS)
-    .eq('id', id)
-    .eq('status', 'approved')
-    .maybeSingle(); // null if not found instead of throwing
+  const row = await withFieldFallback<StickerRow | null>(
+    (fields) =>
+      supabase
+        .from('stickers')
+        .select(fields)
+        .eq('id', id)
+        .eq('status', 'approved')
+        .maybeSingle(), // null if not found instead of throwing
+    null,
+  );
 
-  if (error) throw error;
-  return (data as Sticker | null) ?? null; // Sticker | null
+  return row ? normalizeStickerRow(row) : null;
 }
 
 /** Optional attached experiences */
@@ -62,4 +73,172 @@ export async function fetchExperiences(stickerId: string): Promise<Experience[]>
     return [];
   }
   return (data as Experience[] | null) ?? [];
+}
+
+type StickerRow = (Sticker & UnknownRecord) | UnknownRecord;
+
+async function withFieldFallback<T>(
+  runQuery: (
+    fields: (typeof STICKER_FIELD_VARIANTS)[number],
+  ) => PromiseLike<any>,
+  fallback: T,
+): Promise<T> {
+  let lastColumnError: unknown = null;
+
+  for (const fields of STICKER_FIELD_VARIANTS) {
+    const response = (await runQuery(fields)) as { data: T | null; error: unknown };
+    const { data, error } = response;
+
+    if (!error) {
+      return (data ?? fallback) as T;
+    }
+
+    if (!isMissingColumnError(error)) {
+      throw error;
+    }
+
+    lastColumnError = error;
+  }
+
+  if (lastColumnError) {
+    console.warn('[supabase] sticker location columns missing – falling back without coordinates');
+  }
+
+  return fallback;
+}
+
+function normalizeStickerRow(row: StickerRow): Sticker {
+  const record = row as UnknownRecord;
+  const { latitude, longitude } = extractCoordinates(record);
+  const id = typeof record.id === 'string' ? record.id : String(record.id ?? '');
+  const status = normalizeStatus(record.status);
+
+  return {
+    id,
+    title: (record.title as Sticker['title']) ?? null,
+    artist_name: (record.artist_name as Sticker['artist_name']) ?? null,
+    image_url: (record.image_url as Sticker['image_url']) ?? null,
+    status,
+    created_at: typeof record.created_at === 'string' ? record.created_at : undefined,
+    latitude: latitude ?? undefined,
+    longitude: longitude ?? undefined,
+  };
+}
+
+function extractCoordinates(record: UnknownRecord): { latitude: number | null; longitude: number | null } {
+  let latitude = pickCoordinate(record, LATITUDE_KEYS);
+  let longitude = pickCoordinate(record, LONGITUDE_KEYS);
+
+  if (latitude != null && longitude != null) {
+    return { latitude, longitude };
+  }
+
+  const locationSource = record.location ?? record.geo_location ?? record.coordinates;
+
+  if (typeof locationSource === 'string') {
+    const parsed = parsePointString(locationSource);
+    if (parsed) {
+      latitude ??= parsed.latitude;
+      longitude ??= parsed.longitude;
+    }
+  } else if (Array.isArray(locationSource)) {
+    if (locationSource.length >= 2) {
+      longitude ??= toNumber(locationSource[0]);
+      latitude ??= toNumber(locationSource[1]);
+    }
+  } else if (locationSource && typeof locationSource === 'object') {
+    const locationRecord = locationSource as UnknownRecord;
+    latitude ??= pickCoordinate(locationRecord, [...LATITUDE_KEYS, 'y']);
+    longitude ??= pickCoordinate(locationRecord, [...LONGITUDE_KEYS, 'x']);
+
+    const coordinates = locationRecord.coordinates;
+    if (Array.isArray(coordinates) && coordinates.length >= 2) {
+      longitude ??= toNumber(coordinates[0]);
+      latitude ??= toNumber(coordinates[1]);
+    }
+  }
+
+  return {
+    latitude: latitude ?? null,
+    longitude: longitude ?? null,
+  };
+}
+
+function normalizeStatus(value: unknown): Sticker['status'] {
+  if (typeof value === 'string') {
+    if (value === 'approved' || value === 'pending' || value === 'flagged') {
+      return value;
+    }
+  }
+  return 'pending';
+}
+
+const LATITUDE_KEYS = [
+  'latitude',
+  'lat',
+  'location_latitude',
+  'location_lat',
+  'geo_latitude',
+  'geo_lat',
+  'sticker_latitude',
+  'sticker_lat',
+];
+
+const LONGITUDE_KEYS = [
+  'longitude',
+  'lng',
+  'lon',
+  'long',
+  'location_longitude',
+  'location_long',
+  'geo_longitude',
+  'geo_long',
+  'sticker_longitude',
+  'sticker_long',
+];
+
+function pickCoordinate(source: UnknownRecord, keys: string[]): number | null {
+  for (const key of keys) {
+    if (!(key in source)) continue;
+    const value = source[key];
+    const numeric = toNumber(value);
+    if (numeric != null) {
+      return numeric;
+    }
+  }
+  return null;
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = Number.parseFloat(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function parsePointString(value: string): { latitude: number; longitude: number } | null {
+  const match = value.match(/POINT\s*\(([-\d.+eE]+)\s+([\-\d.+eE]+)\)/);
+  if (!match) return null;
+  const longitude = Number.parseFloat(match[1]);
+  const latitude = Number.parseFloat(match[2]);
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+    return null;
+  }
+  return { latitude, longitude };
+}
+
+function isMissingColumnError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const err = error as { code?: unknown; message?: unknown };
+  if (err.code === '42703') return true;
+  if (typeof err.message === 'string') {
+    return /does not exist$/i.test(err.message) || /column.+does not exist/i.test(err.message);
+  }
+  return false;
 }


### PR DESCRIPTION
## Summary
- add Supabase select fallbacks so missing latitude/longitude columns no longer break sticker queries
- normalize sticker rows and extract coordinates from multiple schema shapes, enabling map rendering even when location fields differ

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e676e7fad08332a4c9993cf638c2b1