### PR TITLE
Add Supabase env config for Expo runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and fill in your Supabase project details.
+EXPO_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ To run the development server:
     bun dev
 ```
 
+After installing dependencies, duplicate the provided environment template so Expo can load the Supabase credentials at runtime:
+
+```bash
+cp .env.example .env
+```
+
+Update the values in `.env` with your Supabase project's URL and anon key before starting the dev server.
+
 This will start the Expo Dev Server. Open the app in:
 
 - **iOS**: press `i` to launch in the iOS simulator _(Mac only)_


### PR DESCRIPTION
## Summary
- add an example Supabase environment file exposing EXPO_PUBLIC variables
- document copying the template so Expo can read Supabase credentials during dev

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e67a5ec8148332b58e7c2ac186c242