### PR TITLE
Add auth provider and sign in helpers

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,6 +7,7 @@ import 'react-native-reanimated'
 import '@/global.css'
 
 import React from 'react'
+import { AuthProvider } from '@/lib/auth'
 import { NAV_THEME } from '@/lib/theme'
 import { HeaderMenu } from '@/components/header-menu'
 import { ThemeProvider } from '@react-navigation/native'
@@ -61,11 +62,13 @@ export default function RootLayout() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <QueryClientProvider client={queryClient}>
-        <ThemeProvider value={NAV_THEME[colorScheme ?? 'light']}>
-          <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
-          <Stack screenOptions={{ headerRight: () => <HeaderMenu /> }} />
-          <PortalHost />
-        </ThemeProvider>
+        <AuthProvider>
+          <ThemeProvider value={NAV_THEME[colorScheme ?? 'light']}>
+            <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
+            <Stack screenOptions={{ headerRight: () => <HeaderMenu /> }} />
+            <PortalHost />
+          </ThemeProvider>
+        </AuthProvider>
       </QueryClientProvider>
     </GestureHandlerRootView>
   )

--- a/lib/auth.tsx
+++ b/lib/auth.tsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import type { Session, User } from '@supabase/supabase-js'
+
+import { getSupabaseClient, getSupabaseConfigurationError } from './supabase'
+
+export type AuthContextValue = {
+  session: Session | null
+  user: User | null
+  loading: boolean
+}
+
+const AuthContext = React.createContext<AuthContextValue | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [session, setSession] = React.useState<Session | null>(null)
+  const [user, setUser] = React.useState<User | null>(null)
+  const [loading, setLoading] = React.useState(true)
+
+  React.useEffect(() => {
+    let isMounted = true
+
+    const configError = getSupabaseConfigurationError()
+    if (configError) {
+      setLoading(false)
+      return () => {
+        isMounted = false
+      }
+    }
+
+    let unsubscribe: (() => void) | undefined
+
+    try {
+      const client = getSupabaseClient()
+
+      client.auth
+        .getSession()
+        .then(({ data }) => {
+          if (!isMounted) return
+          setSession(data.session ?? null)
+          setUser(data.session?.user ?? null)
+          setLoading(false)
+        })
+        .catch(() => {
+          if (!isMounted) return
+          setLoading(false)
+        })
+
+      const { data: authListener } = client.auth.onAuthStateChange((_event, nextSession) => {
+        if (!isMounted) return
+        setSession(nextSession ?? null)
+        setUser(nextSession?.user ?? null)
+        setLoading(false)
+      })
+
+      unsubscribe = () => authListener?.subscription.unsubscribe()
+    } catch (error) {
+      console.warn(error)
+      setLoading(false)
+    }
+
+    return () => {
+      isMounted = false
+      unsubscribe?.()
+    }
+  }, [])
+
+  const value = React.useMemo<AuthContextValue>(() => ({ session, user, loading }), [session, user, loading])
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+export function useAuth() {
+  const context = React.useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}
+
+export async function signInWithEmail(email: string) {
+  const client = getSupabaseClient()
+  return client.auth.signInWithOtp({ email, options: { shouldCreateUser: true } })
+}
+
+export async function signOut() {
+  const client = getSupabaseClient()
+  return client.auth.signOut()
+}


### PR DESCRIPTION
## Summary
- add a Supabase-backed AuthProvider with hook and helper utilities
- wrap the app router with the new provider so auth state is available throughout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e67a677e848332828cde1ea149a710