### PR TITLE
Add stickers fetch API and wire home list

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -11,7 +11,7 @@ import { Center } from '@/components/ui/center';
 import { Button } from '@/components/ui/button';
 import { Icon } from '@/components/ui/icon';
 import { THEME } from '@/lib/theme';
-import { fetchApprovedStickers, type Sticker } from '@/features/stickers/api';
+import { fetchStickers, type Sticker } from '@/features/stickers/api';
 import { getSupabaseConfigurationError } from '@/lib/supabase';
 import { MapPinIcon, MoonStarIcon, SunIcon } from 'lucide-react-native';
 
@@ -62,7 +62,7 @@ export default function BrowseScreen() {
     isFetching,
   } = useQuery<Sticker[]>({
     queryKey: ['stickers'],
-    queryFn: fetchApprovedStickers,
+    queryFn: fetchStickers,
     enabled: isHydrated && !supabaseConfigError,
     retry: 0,
   });

--- a/features/stickers/api.ts
+++ b/features/stickers/api.ts
@@ -28,7 +28,7 @@ const STICKER_FIELD_VARIANTS = [
 const EXPERIENCE_FIELDS = 'id,sticker_id,type,payload';
 
 /** Grid list */
-export async function fetchApprovedStickers(): Promise<Sticker[]> {
+export async function fetchStickers(): Promise<Sticker[]> {
   const supabase = getSupabaseClient();
   const rows = await withFieldFallback<StickerRow[]>(
     (fields) =>
@@ -42,6 +42,9 @@ export async function fetchApprovedStickers(): Promise<Sticker[]> {
 
   return rows.map(normalizeStickerRow);
 }
+
+/** @deprecated Use {@link fetchStickers} instead. */
+export const fetchApprovedStickers = fetchStickers;
 
 /** Details page */
 export async function fetchStickerById(id: string) {


### PR DESCRIPTION
## Summary
- expose a public `fetchStickers` helper that reads approved rows from `public.stickers`
- update the home screen query to use the new fetch helper when rendering the sticker grid

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e67a84180c83329b709af02f4c7333