### PR TITLE
Add sticker experience types and routing

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -11,7 +11,8 @@ import { Center } from '@/components/ui/center';
 import { Button } from '@/components/ui/button';
 import { Icon } from '@/components/ui/icon';
 import { THEME } from '@/lib/theme';
-import { fetchApprovedStickers, type Sticker } from '@/features/stickers/api';
+import { fetchApprovedStickers } from '@/features/stickers/api';
+import type { Sticker } from '@/features/stickers/types';
 import { getSupabaseConfigurationError } from '@/lib/supabase';
 import { MapPinIcon, MoonStarIcon, SunIcon } from 'lucide-react-native';
 

--- a/app/map.tsx
+++ b/app/map.tsx
@@ -19,7 +19,8 @@ import { MapPinIcon, RotateCcwIcon } from 'lucide-react-native';
 import { Center } from '@/components/ui/center';
 import { Button } from '@/components/ui/button';
 import { Icon } from '@/components/ui/icon';
-import { fetchApprovedStickers, type Sticker } from '@/features/stickers/api';
+import { fetchApprovedStickers } from '@/features/stickers/api';
+import type { Sticker } from '@/features/stickers/types';
 import { getSupabaseConfigurationError } from '@/lib/supabase';
 import { THEME } from '@/lib/theme';
 

--- a/app/sticker/[id].tsx
+++ b/app/sticker/[id].tsx
@@ -8,8 +8,9 @@ import { useQuery } from '@tanstack/react-query';
 import { Center } from '@/components/ui/center';
 import { GhostButton } from '@/components/ui/ghost-button';
 import { ErrorView } from '@/components/ui/error-view';
-import { fetchStickerById, fetchExperiences, type Experience, type Sticker } from '@/features/stickers/api';
-import { openExperience } from '@/lib/experience';
+import { fetchStickerById, fetchExperiences } from '@/features/stickers/api';
+import type { Experience, Sticker } from '@/features/stickers/types';
+import { getExperienceCta, openExperience } from '@/lib/experience';
 import { getSupabaseConfigurationError } from '@/lib/supabase';
 
 export default function StickerDetails() {
@@ -83,17 +84,6 @@ export default function StickerDetails() {
       await openExperience(exp);
     } catch (e: any) {
       Alert.alert('Could not open', e?.message ?? 'Unknown error');
-    }
-  }, []);
-
-  const getCtaText = React.useCallback((exp: Experience) => {
-    switch (exp.type) {
-      case 'ar':
-        return 'Open AR';
-      case 'url':
-        return 'Open Link';
-      default:
-        return `Open ${String(exp.type).replace(/_/g, ' ')}`;
     }
   }, []);
 
@@ -180,7 +170,7 @@ export default function StickerDetails() {
                     alignItems: 'center',
                   }}
                 >
-                  <Text style={{ color: 'white', fontWeight: '600' }}>{getCtaText(exp)}</Text>
+                  <Text style={{ color: 'white', fontWeight: '600' }}>{getExperienceCta(exp.type)}</Text>
                 </Pressable>
               ))
             )}

--- a/features/stickers/api.ts
+++ b/features/stickers/api.ts
@@ -1,30 +1,15 @@
 // features/stickers/api.ts
 import { getSupabaseClient } from '@/lib/supabase';
 
+import type { Experience, Sticker } from './types';
+
 type UnknownRecord = Record<string, unknown>;
-
-export type Sticker = {
-  id: string;
-  title: string | null;
-  artist_name: string | null;
-  image_url: string | null;
-  latitude?: number | null;
-  longitude?: number | null;
-  status: 'pending' | 'approved' | 'flagged';
-  created_at?: string;
-};
-
-export type Experience = {
-  id: string;
-  sticker_id: string;
-  type: 'url' | 'webgl' | 'ar' | 'deep_link';
-  payload: Record<string, any> | null;
-};
 
 const STICKER_FIELD_VARIANTS = [
   'id,title,artist_name,image_url,latitude,longitude,status,created_at',
   '*',
 ] as const;
+
 const EXPERIENCE_FIELDS = 'id,sticker_id,type,payload';
 
 /** Grid list */
@@ -72,6 +57,7 @@ export async function fetchExperiences(stickerId: string): Promise<Experience[]>
     console.warn('[supabase] experiences error', error);
     return [];
   }
+
   return (data as Experience[] | null) ?? [];
 }
 
@@ -242,3 +228,4 @@ function isMissingColumnError(error: unknown): boolean {
   }
   return false;
 }
+

--- a/features/stickers/types.ts
+++ b/features/stickers/types.ts
@@ -1,0 +1,23 @@
+// features/stickers/types.ts
+
+export type StickerStatus = 'pending' | 'approved' | 'flagged';
+
+export type Sticker = {
+  id: string;
+  title: string | null;
+  artist_name: string | null;
+  image_url: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  status: StickerStatus;
+  created_at?: string;
+};
+
+export type ExperienceType = 'url' | 'webgl' | 'ar' | 'deep_link';
+
+export type Experience = {
+  id: string;
+  sticker_id: string;
+  type: ExperienceType;
+  payload: Record<string, unknown> | null;
+};

--- a/lib/experience.ts
+++ b/lib/experience.ts
@@ -1,44 +1,69 @@
 // lib/experience.ts
 import * as Linking from 'expo-linking';
-import { Alert, Platform } from 'react-native';
+import { Alert } from 'react-native';
 
-// Minimal local Experience type because '@/features/stickers/api' does not export it.
-// If the real module later exports a matching type, replace this local type with that import.
-type Experience = {
-  type: 'deep_link' | 'ar' | 'webgl' | 'url' | string;
-  payload?: any;
+import type { Experience } from '@/features/stickers/types';
+
+const EXPERIENCE_LABELS: Record<Experience['type'], string> = {
+  url: 'Open Link',
+  webgl: 'Open WebGL',
+  ar: 'Open AR',
+  deep_link: 'Open App',
 };
 
-export function pickUrlFromPayload(payload: any, type: Experience['type']): string | null {
-  if (!payload) return null;
-  // accept common keys
-  const candidates = [
-    payload.url, payload.href, payload.link,
-    payload.deep_link, payload.deeplink,
-    payload.webgl, payload.ar,
-  ].filter(Boolean);
-  // prefer by type, fall back to first truthy
-  if (type === 'deep_link' || type === 'ar') {
-    return payload.deep_link || payload.ar || candidates[0] || null;
-  }
-  if (type === 'webgl' || type === 'url') {
-    return payload.url || payload.webgl || candidates[0] || null;
-  }
-  return candidates[0] || null;
+const EXPERIENCE_KEY_PRIORITY: Record<Experience['type'], string[]> = {
+  url: ['url', 'href', 'link'],
+  webgl: ['webgl', 'url', 'href'],
+  ar: ['ar', 'deep_link', 'deeplink', 'url'],
+  deep_link: ['deep_link', 'deeplink', 'url'],
+};
+
+const FALLBACK_KEYS = ['link', 'href', 'url', 'webgl', 'deep_link', 'deeplink', 'ar'];
+
+export function getExperienceCta(type: Experience['type']): string {
+  return EXPERIENCE_LABELS[type] ?? `Open ${formatExperienceType(type)}`;
 }
 
 export async function openExperience(exp: Experience) {
-  const target = pickUrlFromPayload(exp.payload, exp.type);
+  const target = resolveExperienceUrl(exp);
+
   if (!target) {
     Alert.alert('No experience URL', 'This sticker has no attached link yet.');
     return;
   }
+
   try {
-    const can = await Linking.canOpenURL(target);
-    if (!can) throw new Error('Cannot open URL');
+    const canOpen = await Linking.canOpenURL(target);
+    if (!canOpen) {
+      throw new Error(`Cannot open URL: ${target}`);
+    }
+
     await Linking.openURL(target);
-  } catch {
-    const label = Platform.select({ ios: 'Share Sheet', android: 'Copy URL', default: 'Copy URL' });
-    Alert.alert('Could not open', `Try again later.\n\nURL:\n${target}`, [{ text: label }]);
+  } catch (error) {
+    console.warn('[experience] failed to open', { experience: exp, error });
+    Alert.alert('Could not open', `Try again later.\n\nURL:\n${target}`);
   }
+}
+
+function resolveExperienceUrl(exp: Experience): string | null {
+  const keys = EXPERIENCE_KEY_PRIORITY[exp.type] ?? [];
+  const payload = exp.payload ?? {};
+
+  for (const key of [...keys, ...FALLBACK_KEYS]) {
+    const value = (payload as Record<string, unknown>)[key];
+    const stringValue = typeof value === 'string' ? value.trim() : null;
+    if (stringValue) {
+      return stringValue;
+    }
+  }
+
+  return null;
+}
+
+function formatExperienceType(type: Experience['type']): string {
+  return type
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase() + part.slice(1))
+    .join(' ');
 }


### PR DESCRIPTION
## Summary
- move sticker and experience type definitions into a shared module
- update Supabase API helpers and sticker detail screen to consume sticker experiences
- enhance the experience helper to choose per-type CTAs and URL targets

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e67a8c878883328598cd295094bf31