### PR TITLE
Add pg_cron schedules for auth maintenance

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,53 @@
+# Analytics Maintenance Tasks
+
+The Supabase instance uses `pg_cron` to keep the auth rollups healthy. After running
+`scripts`/`psql` with `supabase/sql/cron_jobs.sql`, verify the following:
+
+## Cron registrations
+
+```sql
+select jobname, schedule, command
+from cron.job
+where jobname in (
+  'refresh_mv_auth_daily',
+  'purge_old_auth_events',
+  'auth_signin_health_check'
+)
+order by jobname;
+```
+
+You should see three rows (one per task) with the schedules `0 5 * * *`, `30 4 * * *`, and `15 6 * * *`.
+
+## Materialized view freshness
+
+```sql
+refresh materialized view public.mv_auth_daily;
+```
+
+Re-running the command manually should succeed without errors, confirming the job command is valid.
+
+## Raw event retention
+
+```sql
+select count(*)
+from raw.auth_events
+where occurred_at < now() - interval '90 days';
+```
+
+The count should trend toward zero after the nightly purge job runs.
+
+## Sign-in health alert
+
+```sql
+insert into analytics.auth_event_alerts (alerted_at, alert_message)
+select now(), 'Test run'
+where not exists (
+  select 1
+  from raw.auth_events
+  where event_type = 'sign_in'
+    and occurred_at >= now() - interval '24 hours'
+);
+```
+
+Running the insert in an environment with no sign-ins in the last 24 hours should add a row to
+`analytics.auth_event_alerts`, mirroring what the cron job performs.

--- a/supabase/sql/cron_jobs.sql
+++ b/supabase/sql/cron_jobs.sql
@@ -1,0 +1,40 @@
+-- Enable pg_cron so that we can schedule recurring maintenance tasks.
+create extension if not exists "pg_cron";
+
+-- Nightly refresh of the daily auth materialized view so dashboards stay fresh.
+select
+  cron.schedule(
+    job_name => 'refresh_mv_auth_daily',
+    schedule => '0 5 * * *',
+    command => $$
+      refresh materialized view public.mv_auth_daily;
+    $$
+  );
+
+-- Daily purge of raw auth events older than 90 days to enforce retention requirements.
+select
+  cron.schedule(
+    job_name => 'purge_old_auth_events',
+    schedule => '30 4 * * *',
+    command => $$
+      delete from raw.auth_events
+      where occurred_at < now() - interval '90 days';
+    $$
+  );
+
+-- Daily health check: alert if we have seen zero sign-ins in the past 24 hours.
+select
+  cron.schedule(
+    job_name => 'auth_signin_health_check',
+    schedule => '15 6 * * *',
+    command => $$
+      insert into analytics.auth_event_alerts (alerted_at, alert_message)
+      select now(), 'No sign-ins detected in the last 24 hours'
+      where not exists (
+        select 1
+        from raw.auth_events
+        where event_type = 'sign_in'
+          and occurred_at >= now() - interval '24 hours'
+      );
+    $$
+  );


### PR DESCRIPTION
## Summary
- enable the pg_cron extension and schedule nightly refresh, retention, and health-check jobs for auth data
- add analytics documentation with the verification queries needed to confirm each job is working

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e67ab5e90c8332a4218ee44e37058a