### PR TITLE
Fix duplicate Sticker import on browse screen

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -11,9 +11,8 @@ import { Center } from '@/components/ui/center';
 import { Button } from '@/components/ui/button';
 import { Icon } from '@/components/ui/icon';
 import { THEME } from '@/lib/theme';
-import { fetchApprovedStickers } from '@/features/stickers/api';
+import { fetchStickers } from '@/features/stickers/api';
 import type { Sticker } from '@/features/stickers/types';
-import { fetchStickers, type Sticker } from '@/features/stickers/api';
 import { getSupabaseConfigurationError } from '@/lib/supabase';
 import { MapPinIcon, MoonStarIcon, SunIcon } from 'lucide-react-native';
 


### PR DESCRIPTION
## Summary
- remove the redundant Sticker type import on the browse screen so the module no longer redeclares the symbol at runtime

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e67cf7421883328dc8533c221ce224