### PR TITLE
Add devcontainer configuration for Codespaces web setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "name": "Node.js Dev Container",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
+  "postCreateCommand": "corepack enable && npm i && npm run web",
+  "forwardPorts": [19006],
+  "portsAttributes": {
+    "19006": {
+      "label": "Expo Web"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Node.js devcontainer image configuration for Codespaces
- run corepack, install dependencies, and start the web server after creation
- expose the Expo web development port for browser access

## Testing
- not run (devcontainer configuration)


------
https://chatgpt.com/codex/tasks/task_e_68e67ec255688332aff46acbbd9e7f5a