### PR TITLE
Configure EAS Update preview channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,43 @@ This will start the Expo Dev Server. Open the app in:
 
 You can also scan the QR code using the [Expo Go](https://expo.dev/go) app on your device. This project fully supports running in Expo Go for quick testing on physical devices.
 
+## EAS Update preview releases
+
+EAS Update enables you to ship OTA previews without submitting a new build to the app stores. This project is pre-configured with a `preview` channel that maps to a matching branch.
+
+### 1. Install the CLI and authenticate
+
+```bash
+npm install
+npx eas login
+```
+
+If you're using CI, set the `EXPO_TOKEN` environment variable instead of logging in interactively. Running `npx eas init` afterwards will register the project with your Expo account and replace `YOUR-EAS-PROJECT-ID` in [`app.json`](./app.json) with the real project ID.
+
+### 2. Create the preview branch and channel
+
+```bash
+npx eas branch:create preview
+npx eas channel:create preview --branch preview
+```
+
+### 3. Publish updates to the preview channel
+
+```bash
+npx eas update --branch preview --message "preview"
+# or with the included npm script
+npm run eas:update:preview
+```
+
+Every publish prints a "Project page" URL containing the QR code and shareable link for the release (for example: `https://expo.dev/accounts/<account>/projects/stikemup-app?release-channel=preview`). Share that URL with teammates so they can install the OTA update.
+
+### Loading the preview on devices
+
+1. Install the [Expo Go](https://expo.dev/go) app (or a custom development build) on the target iOS/Android device.
+2. Open the "Project page" URL generated after publishing. The page shows both a QR code and a "Open project" button.
+3. Scan the QR code with Expo Go or tap the button on the device to load the latest preview update from the `preview` channel.
+4. Whenever you push another update with `npm run eas:update:preview`, testers just need to refresh the app in Expo Go to receive the new bundle.
+
 ## Adding components
 
 You can add more reusable components using the CLI:

--- a/app.json
+++ b/app.json
@@ -37,6 +37,11 @@
     ],
     "experiments": {
       "typedRoutes": true
+    },
+    "extra": {
+      "eas": {
+        "projectId": "YOUR-EAS-PROJECT-ID"
+      }
     }
   }
 }

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,21 @@
+{
+  "cli": {
+    "version": ">= 6.4.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "channel": "preview",
+      "distribution": "internal"
+    },
+    "production": {
+      "channel": "production"
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "android": "expo start -c --android",
     "ios": "expo start -c --ios",
     "web": "expo start -c --web",
-    "clean": "rm -rf .expo node_modules"
+    "clean": "rm -rf .expo node_modules",
+    "eas": "eas",
+    "eas:update:preview": "eas update --branch preview --message preview"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "2.1.2",
@@ -50,6 +52,7 @@
     "@babel/core": "^7.26.0",
     "@types/react": "~19.0.14",
     "@types/uuid": "^10.0.0",
+    "eas-cli": "^6.4.0",
     "babel-plugin-module-resolver": "^5.0.2",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14",


### PR DESCRIPTION
## Summary
- add eas-cli as a development dependency with helper scripts for publishing preview updates
- add EAS configuration and placeholder project metadata for OTA updates
- document the preview branch/channel workflow and how to access preview builds via QR/links

## Testing
- npm install -D eas-cli *(fails: registry returned 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e67eba40688332a2d194ed6b0d74ed