### PR TITLE
Configure Vercel static export for Expo web build

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ This will start the Expo Dev Server. Open the app in:
 
 You can also scan the QR code using the [Expo Go](https://expo.dev/go) app on your device. This project fully supports running in Expo Go for quick testing on physical devices.
 
+## Web deployment (Vercel)
+
+- Build the static web bundle with `npm run build:web`. This runs `expo export` and writes the optimized web output to the `dist/` directory.
+- Deploy the project to Vercel with the build command set to `npm run build:web` and the output directory set to `dist/`.
+- The included [`vercel.json`](./vercel.json) configures a single-page-app rewrite (`/(.*) → /`) so [Expo Router](https://expo.dev/router) dynamic routes resolve correctly when a user reloads or deep-links to nested paths.
+
 ## Adding components
 
 You can add more reusable components using the CLI:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "android": "expo start -c --android",
     "ios": "expo start -c --ios",
     "web": "expo start -c --web",
+    "build:web": "expo export --platform web --output-dir dist",
     "clean": "rm -rf .expo node_modules"
   },
   "dependencies": {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "buildCommand": "npm run build:web",
+  "outputDirectory": "dist",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Vercel configuration with SPA rewrites and Expo web export settings
- expose an npm build:web script that runs expo export for the web bundle
- document the deployment workflow in the README for Vercel builds

## Testing
- npm run build:web

------
https://chatgpt.com/codex/tasks/task_e_68e67eaef8608332a29833a0e2f4c84f