### PR TITLE
fix: pull vercel env before expo build

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -28,12 +28,12 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
-      - name: Build web app
-        run: npm run build --if-present
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Pull Vercel environment
         run: vercel pull --yes --environment=preview --token=$VERCEL_TOKEN
+      - name: Build web app
+        run: npm run build --if-present
       - name: Generate Vercel build output
         run: vercel build --token=$VERCEL_TOKEN
       - name: Create preview deployment


### PR DESCRIPTION
## Summary
- install the Vercel CLI before building the Expo web bundle in the preview workflow
- pull the preview environment variables before running the Expo build so env vars are embedded in the bundle

## Testing
- not run (workflow automation only)

------
https://chatgpt.com/codex/tasks/task_e_68e683926f3c8332a88efcd88484f61a