### PR TITLE
Adjust devcontainer commands to avoid long-running postCreate

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 {
   "name": "Node.js Dev Container",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
-  "postCreateCommand": "corepack enable && npm i && npm run web",
+  "postCreateCommand": "corepack enable && npm install",
+  "postAttachCommand": "npm run web",
   "forwardPorts": [19006],
   "portsAttributes": {
     "19006": {


### PR DESCRIPTION
## Summary
- keep the devcontainer post-create hook limited to dependency setup
- start the Expo web server after attachment instead of during creation

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68e68395a87c83329388233f113dbb16