### PR TITLE
Restrict experiences access to approved stickers

### DIFF
--- a/supabase/minimal_schema.sql
+++ b/supabase/minimal_schema.sql
@@ -38,11 +38,16 @@ create index if not exists experiences_sticker_id_idx
 
 alter table public.experiences enable row level security;
 
-drop policy if exists "Experiences are readable" on public.experiences;
-create policy "Experiences are readable"
+drop policy if exists "Experiences for approved stickers" on public.experiences;
+create policy "Experiences for approved stickers"
     on public.experiences
     for select
-    using (true);
+    using (exists (
+        select 1
+        from public.stickers s
+        where s.id = sticker_id
+          and s.status = 'approved'
+    ));
 
 create table if not exists public.captures (
     id uuid primary key default gen_random_uuid(),


### PR DESCRIPTION
## Summary
- update the experiences RLS policy to only return rows whose sticker is approved

## Testing
- not run (schema-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e6839802848332b9ad42619ee0d244