### PR TITLE
Handle sticker location schema drift

### DIFF
--- a/features/stickers/api.ts
+++ b/features/stickers/api.ts
@@ -238,7 +238,7 @@ function isMissingColumnError(error: unknown): boolean {
   const err = error as { code?: unknown; message?: unknown };
   if (err.code === '42703') return true;
   if (typeof err.message === 'string') {
-    return /does not exist$/i.test(err.message) || /column.+does not exist/i.test(err.message);
+    return /\b(column|attribute)\b[^.]*does not exist/i.test(err.message);
   }
   return false;
 }


### PR DESCRIPTION
## Summary
- add Supabase select fallbacks so missing latitude/longitude columns no longer break sticker queries
- normalize sticker rows and extract coordinates from multiple schema shapes, enabling map rendering even when location fields differ
- restrict missing-column detection to column-specific errors so relation failures still surface

## Testing
- npx tsc --noEmit *(fails: expo/react-native dependencies and JSX config missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e68a6816c88332907b256d43865191