### PR TITLE
Follow-up: Ensure audit events policy recreation succeeds

### DIFF
--- a/supabase_events_setup.sql
+++ b/supabase_events_setup.sql
@@ -22,11 +22,12 @@ comment on table public.events is 'Server-sourced auth events synced from auth.a
 alter table public.events
   alter column metadata set default '{}'::jsonb;
 
--- Enable row level security so that per-user policies can keep the audit mirror private.
 alter table public.events enable row level security;
 
 -- Allow authenticated clients to read only their own audit events.
-create policy if not exists "Authenticated users can read own events"
+drop policy if exists "Authenticated users can read own events" on public.events;
+
+create policy "Authenticated users can read own events"
   on public.events
   for select
   to authenticated


### PR DESCRIPTION
## Summary
- drop the existing authenticated select policy before recreating it so the script avoids unsupported IF NOT EXISTS syntax

## Testing
- not run (SQL change only)


------
https://chatgpt.com/codex/tasks/task_e_68e68b8004c083328a01c0efeff5f9e7