### PR TITLE
Allow schema-qualified missing column errors to fall back

### DIFF
--- a/features/stickers/api.ts
+++ b/features/stickers/api.ts
@@ -238,7 +238,7 @@ function isMissingColumnError(error: unknown): boolean {
   const err = error as { code?: unknown; message?: unknown };
   if (err.code === '42703') return true;
   if (typeof err.message === 'string') {
-    return /\b(column|attribute)\b[^.]*does not exist/i.test(err.message);
+    return /\b(column|attribute)\b[\s"'.\w-]*does not exist/i.test(err.message);
   }
   return false;
 }


### PR DESCRIPTION
## Summary
- expand missing-column regex to accept schema-qualified relation names

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e68b7f94e083329fbcd990060ca50e