### PR TITLE
Ensure experiences RLS drops legacy policy name

### DIFF
--- a/supabase/minimal_schema.sql
+++ b/supabase/minimal_schema.sql
@@ -38,6 +38,7 @@ create index if not exists experiences_sticker_id_idx
 
 alter table public.experiences enable row level security;
 
+drop policy if exists "Experiences are readable" on public.experiences;
 drop policy if exists "Experiences for approved stickers" on public.experiences;
 create policy "Experiences for approved stickers"
     on public.experiences


### PR DESCRIPTION
## Summary
- drop the legacy "Experiences are readable" policy before adding the approved-sticker policy so RLS restrictions apply cleanly

## Testing
- not run (schema-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e68b7cb7c883328a8d84f19219edea