### PR TITLE
Handle missing Supabase config gracefully and clean up web shadows

### DIFF
--- a/app/dev/auth-test.tsx
+++ b/app/dev/auth-test.tsx
@@ -2,7 +2,7 @@
 import React, { useMemo, useState } from 'react';
 import { View, TextInput, Button, Text } from 'react-native';
 
-import { getSupabaseClient, getSupabaseConfigurationError } from '@/lib/supabase';
+import { getSupabaseConfigurationError, tryGetSupabaseClient } from '@/lib/supabase';
 
 export default function AuthTest() {
   const [email, setEmail] = useState('');
@@ -12,7 +12,7 @@ export default function AuthTest() {
   const supabaseConfigError = getSupabaseConfigurationError();
   const supabase = useMemo(() => {
     if (supabaseConfigError) return null;
-    return getSupabaseClient();
+    return tryGetSupabaseClient();
   }, [supabaseConfigError]);
 
   if (supabaseConfigError) {

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -16,7 +16,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input';
 import { Text } from '@/components/ui/text';
 import { THEME } from '@/lib/theme';
-import { getSupabaseClient, getSupabaseConfigurationError } from '@/lib/supabase';
+import { getSupabaseConfigurationError, tryGetSupabaseClient } from '@/lib/supabase';
 
 const HEADER_OPTIONS = {
   light: {
@@ -41,7 +41,7 @@ export default function AuthScreen() {
   const supabaseConfigError = getSupabaseConfigurationError();
   const supabase = React.useMemo(() => {
     if (supabaseConfigError) return null;
-    return getSupabaseClient();
+    return tryGetSupabaseClient();
   }, [supabaseConfigError]);
 
   const [mode, setMode] = React.useState<Mode>('sign-in');

--- a/app/sign-in.tsx
+++ b/app/sign-in.tsx
@@ -16,7 +16,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input';
 import { Text } from '@/components/ui/text';
 import { THEME } from '@/lib/theme';
-import { getSupabaseClient, getSupabaseConfigurationError } from '@/lib/supabase';
+import { getSupabaseConfigurationError, tryGetSupabaseClient } from '@/lib/supabase';
 
 const MODES = [
   { id: 'magic-link', label: 'Magic link' },
@@ -31,12 +31,7 @@ export default function SignInScreen() {
   const supabaseConfigError = getSupabaseConfigurationError();
   const supabase = React.useMemo(() => {
     if (supabaseConfigError) return null;
-    try {
-      return getSupabaseClient();
-    } catch (err) {
-      console.warn(err);
-      return null;
-    }
+    return tryGetSupabaseClient();
   }, [supabaseConfigError]);
 
   const [mode, setMode] = React.useState<SignInMode>('magic-link');

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -3,6 +3,8 @@ import { cn } from '@/lib/utils';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Platform, Pressable } from 'react-native';
 
+const nativeShadowClass = Platform.select({ web: '', default: 'shadow-sm shadow-black/5' });
+
 const buttonVariants = cva(
   cn(
     'group shrink-0 flex-row items-center justify-center gap-2 rounded-md shadow-none',
@@ -14,23 +16,27 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: cn(
-          'bg-primary active:bg-primary/90 shadow-sm shadow-black/5',
+          nativeShadowClass,
+          'bg-primary active:bg-primary/90',
           Platform.select({ web: 'hover:bg-primary/90' })
         ),
         destructive: cn(
-          'bg-destructive active:bg-destructive/90 dark:bg-destructive/60 shadow-sm shadow-black/5',
+          nativeShadowClass,
+          'bg-destructive active:bg-destructive/90 dark:bg-destructive/60',
           Platform.select({
             web: 'hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40',
           })
         ),
         outline: cn(
-          'border-border bg-background active:bg-accent dark:bg-input/30 dark:border-input dark:active:bg-input/50 border shadow-sm shadow-black/5',
+          nativeShadowClass,
+          'border-border bg-background active:bg-accent dark:bg-input/30 dark:border-input dark:active:bg-input/50 border',
           Platform.select({
             web: 'hover:bg-accent dark:hover:bg-input/50',
           })
         ),
         secondary: cn(
-          'bg-secondary active:bg-secondary/80 shadow-sm shadow-black/5',
+          nativeShadowClass,
+          'bg-secondary active:bg-secondary/80',
           Platform.select({ web: 'hover:bg-secondary/80' })
         ),
         ghost: cn(
@@ -92,12 +98,22 @@ type ButtonProps = React.ComponentProps<typeof Pressable> &
   React.RefAttributes<typeof Pressable> &
   VariantProps<typeof buttonVariants>;
 
-function Button({ className, variant, size, ...props }: ButtonProps) {
+const WEB_SHADOW = '0px 1px 2px rgba(15, 23, 42, 0.12)';
+const VARIANTS_WITH_SHADOW = new Set(['default', 'destructive', 'outline', 'secondary']);
+
+function Button({ className, variant, size, style, ...props }: ButtonProps) {
+  const variantKey = variant ?? 'default';
+  const shouldApplyWebShadow = Platform.OS === 'web' && VARIANTS_WITH_SHADOW.has(variantKey);
+  const resolvedStyle = shouldApplyWebShadow
+    ? ([{ boxShadow: WEB_SHADOW }, ...(style ? (Array.isArray(style) ? style : [style]) : [])] as ButtonProps['style'])
+    : style;
+
   return (
     <TextClassContext.Provider value={buttonTextVariants({ variant, size })}>
       <Pressable
         className={cn(props.disabled && 'opacity-50', buttonVariants({ variant, size }), className)}
         role="button"
+        style={resolvedStyle}
         {...props}
       />
     </TextClassContext.Provider>

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,15 +1,23 @@
 import { Text, TextClassContext } from '@/components/ui/text';
 import { cn } from '@/lib/utils';
-import { View, type ViewProps } from 'react-native';
+import { Platform, View, type ViewProps } from 'react-native';
 
-function Card({ className, ...props }: ViewProps & React.RefAttributes<View>) {
+function Card({ className, style, ...props }: ViewProps & React.RefAttributes<View>) {
+  const nativeShadowClass = Platform.select({ web: '', default: 'shadow-sm shadow-black/5' });
+  const webShadowStyle = Platform.OS === 'web' ? { boxShadow: '0px 8px 24px rgba(15, 23, 42, 0.08)' } : null;
+  const resolvedStyle = webShadowStyle
+    ? ([webShadowStyle, ...(style ? (Array.isArray(style) ? style : [style]) : [])] as ViewProps['style'])
+    : style;
+
   return (
     <TextClassContext.Provider value="text-card-foreground">
       <View
         className={cn(
-          'bg-card border-border flex flex-col gap-6 rounded-xl border py-6 shadow-sm shadow-black/5',
+          'bg-card border-border flex flex-col gap-6 rounded-xl border py-6',
+          nativeShadowClass,
           className
         )}
+        style={resolvedStyle}
         {...props}
       />
     </TextClassContext.Provider>

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -4,12 +4,21 @@ import { Platform, TextInput, type TextInputProps } from 'react-native';
 function Input({
   className,
   placeholderClassName,
+  style,
   ...props
 }: TextInputProps & React.RefAttributes<TextInput>) {
+  const nativeShadowClass = Platform.select({ web: '', default: 'shadow-sm shadow-black/5' });
+  const webShadowStyle = Platform.OS === 'web' ? { boxShadow: '0px 1px 2px rgba(15, 23, 42, 0.08)' } : null;
+  const resolvedStyle = webShadowStyle
+    ? ([webShadowStyle, ...(style ? (Array.isArray(style) ? style : [style]) : [])] as TextInputProps['style'])
+    : style;
+
   return (
     <TextInput
+      style={resolvedStyle}
       className={cn(
-        'dark:bg-input/30 border-input bg-background text-foreground flex h-10 w-full min-w-0 flex-row items-center rounded-md border px-3 py-1 text-base leading-5 shadow-sm shadow-black/5 sm:h-9',
+        'dark:bg-input/30 border-input bg-background text-foreground flex h-10 w-full min-w-0 flex-row items-center rounded-md border px-3 py-1 text-base leading-5 sm:h-9',
+        nativeShadowClass,
         props.editable === false &&
           cn(
             'opacity-50',

--- a/lib/authEvents.ts
+++ b/lib/authEvents.ts
@@ -6,7 +6,7 @@ import 'react-native-get-random-values'
 import { v4 as uuid } from 'uuid'
 import type { SupabaseClient } from '@supabase/supabase-js'
 
-import { getSupabaseClient, getSupabaseConfigurationError } from './supabase'
+import { getSupabaseConfigurationError, tryGetSupabaseClient } from './supabase'
 
 const DEVICE_KEY = 'stikr_device_id'
 
@@ -74,11 +74,9 @@ export async function wireAuthEvents() {
     return
   }
 
-  let client: SupabaseClient
-  try {
-    client = getSupabaseClient()
-  } catch (error) {
-    console.warn('[authEvents] unable to create Supabase client', error)
+  const client = tryGetSupabaseClient()
+  if (!client) {
+    console.warn('[authEvents] unable to create Supabase client')
     return
   }
 

--- a/lib/logAuthEvent.ts
+++ b/lib/logAuthEvent.ts
@@ -1,5 +1,5 @@
 // src/lib/logAuthEvent.ts
-import { getSupabaseClient, getSupabaseConfigurationError } from './supabase';
+import { getSupabaseConfigurationError, tryGetSupabaseClient } from './supabase';
 
 export async function logAuthEvent(input: {
   type: 'user.signed_in' | 'user.signed_out';
@@ -20,7 +20,11 @@ export async function logAuthEvent(input: {
     return;
   }
 
-  const supabase = getSupabaseClient();
+  const supabase = tryGetSupabaseClient();
+  if (!supabase) {
+    console.warn('logAuthEvent skipped: Supabase client unavailable');
+    return;
+  }
   const { error } = await supabase.functions.invoke('log-event', { body: input });
   if (error) console.warn('logAuthEvent failed:', error);
 }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -30,11 +30,12 @@ type EnvLookupResult = {
 
 function pickEnvValue(keys: readonly string[]): EnvLookupResult {
   for (const key of keys) {
+    const envKey = key as EnvLookupResult['source'];
     const value = process.env[key];
     if (typeof value === 'string') {
       const trimmed = value.trim();
       if (trimmed) {
-        return { value: trimmed, source: key };
+        return { value: trimmed, source: envKey };
       }
     }
   }
@@ -158,6 +159,14 @@ export const isSupabaseConfigured = configurationError == null;
 
 export function getSupabaseConfigurationError() {
   return configurationError;
+}
+
+export function tryGetSupabaseClient(): SupabaseClient | null {
+  if (configurationError) {
+    return null;
+  }
+
+  return getSupabaseClient();
 }
 
 export function getSupabaseClient(): SupabaseClient {


### PR DESCRIPTION
## Summary
- add a tryGetSupabaseClient helper and use it across Supabase-aware modules so preview builds can render without credentials
- update the login, sign-in, and dev auth screens to respect the unavailable-client state instead of throwing
- switch shared UI components to apply boxShadow styles on web while preserving native shadows to silence Expo warnings

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e6c2f1f940833287d0837a488759dc